### PR TITLE
Update core dependencies and refactor modern C# syntax

### DIFF
--- a/SpectreConsoleHost/Builder/Internal/SpectreConsoleHostCommandAppSettings.cs
+++ b/SpectreConsoleHost/Builder/Internal/SpectreConsoleHostCommandAppSettings.cs
@@ -5,13 +5,8 @@ using Spectre.Console.Cli.Help;
 
 namespace Spectre.Console.Builder.Internal
 {
-    internal class SpectreConsoleHostCommandAppSettings : ICommandAppSettings
+    internal class SpectreConsoleHostCommandAppSettings(ITypeRegistrar typeRegistrar) : ICommandAppSettings
     {
-        public SpectreConsoleHostCommandAppSettings(ITypeRegistrar typeRegistrar)
-        {
-            Registrar = new SpectreConsoleHostTypeRegistrarFrontend(typeRegistrar);
-        }
-
         public CultureInfo Culture { get; set; }
         public string ApplicationName { get; set; }
         public string ApplicationVersion { get; set; }
@@ -21,11 +16,12 @@ namespace Spectre.Console.Builder.Internal
         public HelpProviderStyle HelpProviderStyles { get; set; }
         public IAnsiConsole Console { get; set; }
         public ICommandInterceptor Interceptor { get; set; }
-        public ITypeRegistrarFrontend Registrar { get; }
+        public ITypeRegistrarFrontend Registrar { get; } = new SpectreConsoleHostTypeRegistrarFrontend(typeRegistrar);
         public CaseSensitivity CaseSensitivity { get; set; }
         public bool StrictParsing { get; set; }
         public bool ConvertFlagsToRemainingArguments { get; set; }
         public bool PropagateExceptions { get; set; }
+        public int CancellationExitCode { get; set; }
         public bool ValidateExamples { get; set; }
         public Func<Exception, ITypeResolver, int> ExceptionHandler { get; set; }
     }

--- a/SpectreConsoleHost/Builder/Internal/SpectreConsoleHostConfigurator.cs
+++ b/SpectreConsoleHost/Builder/Internal/SpectreConsoleHostConfigurator.cs
@@ -1,33 +1,32 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Spectre.Console.Cli;
 using Spectre.Console.Cli.Help;
 
 namespace Spectre.Console.Builder.Internal
 {
-    internal class SpectreConsoleHostConfigurator : IConfigurator
+    internal class SpectreConsoleHostConfigurator(ITypeRegistrar typeRegistrar) : IConfigurator
     {
         private readonly List<Action<IConfigurator>> _configureActions = new List<Action<IConfigurator>>();
 
-        public SpectreConsoleHostConfigurator(ITypeRegistrar typeRegistrar)
-        {
-            Settings = new SpectreConsoleHostCommandAppSettings(typeRegistrar);
-        }
-
-        public void SetHelpProvider(IHelpProvider helpProvider)
+        public IConfigurator SetHelpProvider(IHelpProvider helpProvider)
         {
             _configureActions.Add(configurator => configurator.SetHelpProvider(helpProvider));
+            return this;
         }
 
-        public void SetHelpProvider<T>() where T : IHelpProvider
+        public IConfigurator SetHelpProvider<T>() where T : IHelpProvider
         {
             _configureActions.Add(configurator => configurator.SetHelpProvider<T>());
+            return this;
         }
 
-        public void AddExample(params string[] args)
+        public IConfigurator AddExample(params string[] args)
         {
             _configureActions.Add(configurator => configurator.AddExample(args));
+            return this;
         }
 
         public ICommandConfigurator AddCommand<TCommand>(string name) where TCommand : class, ICommand
@@ -39,7 +38,7 @@ namespace Spectre.Console.Builder.Internal
             return addCommandConfigurator;
         }
 
-        public ICommandConfigurator AddDelegate<TSettings>(string name, Func<CommandContext, TSettings, int> func) where TSettings : CommandSettings
+        public ICommandConfigurator AddDelegate<TSettings>(string name, Func<CommandContext, TSettings, CancellationToken, int> func) where TSettings : CommandSettings
         {
             var addDelegateConfigurator = new SpectreConsoleHostCommandConfigurator();
         
@@ -48,7 +47,7 @@ namespace Spectre.Console.Builder.Internal
             return addDelegateConfigurator;
         }
 
-        public ICommandConfigurator AddAsyncDelegate<TSettings>(string name, Func<CommandContext, TSettings, Task<int>> func) where TSettings : CommandSettings
+        public ICommandConfigurator AddAsyncDelegate<TSettings>(string name, Func<CommandContext, TSettings, CancellationToken, Task<int>> func) where TSettings : CommandSettings
         {
             var addAsyncDelegateConfigurator = new SpectreConsoleHostCommandConfigurator();
         
@@ -66,7 +65,7 @@ namespace Spectre.Console.Builder.Internal
             return addBranchConfigurator;
         }
 
-        public ICommandAppSettings Settings { get; }
+        public ICommandAppSettings Settings { get; } = new SpectreConsoleHostCommandAppSettings(typeRegistrar);
 
         public void Configure(IConfigurator configurator)
         {

--- a/SpectreConsoleHost/Builder/Internal/SpectreConsoleHostTypeRegistrarFrontend.cs
+++ b/SpectreConsoleHost/Builder/Internal/SpectreConsoleHostTypeRegistrarFrontend.cs
@@ -3,18 +3,11 @@ using Spectre.Console.Cli;
 
 namespace Spectre.Console.Builder.Internal
 {
-    internal class SpectreConsoleHostTypeRegistrarFrontend : ITypeRegistrarFrontend
+    internal class SpectreConsoleHostTypeRegistrarFrontend(ITypeRegistrar typeRegistrar) : ITypeRegistrarFrontend
     {
-        private readonly ITypeRegistrar _typeRegistrar;
-
-        public SpectreConsoleHostTypeRegistrarFrontend(ITypeRegistrar typeRegistrar)
-        {
-            _typeRegistrar = typeRegistrar;
-        }
-
         public void Register<TService, TImplementation>() where TImplementation : TService
         {
-            _typeRegistrar.Register(typeof(TService), typeof(TImplementation));
+            typeRegistrar.Register(typeof(TService), typeof(TImplementation));
         }
 
         public void RegisterInstance<TImplementation>(TImplementation instance)
@@ -22,7 +15,7 @@ namespace Spectre.Console.Builder.Internal
             if (instance == null)
                 throw new ArgumentNullException(nameof(instance));
         
-            _typeRegistrar.RegisterInstance(typeof(TImplementation), instance);
+            typeRegistrar.RegisterInstance(typeof(TImplementation), instance);
         }
 
         public void RegisterInstance<TService, TImplementation>(TImplementation instance) where TImplementation : TService
@@ -30,7 +23,7 @@ namespace Spectre.Console.Builder.Internal
             if (instance == null)
                 throw new ArgumentNullException(nameof(instance));
         
-            _typeRegistrar.RegisterInstance(typeof(TService), instance);
+            typeRegistrar.RegisterInstance(typeof(TService), instance);
         }
     }
 }

--- a/SpectreConsoleHost/Builder/SpectreConsoleHost.cs
+++ b/SpectreConsoleHost/Builder/SpectreConsoleHost.cs
@@ -10,6 +10,6 @@ namespace Spectre.Console.Builder
             return new SpectreConsoleHostBuilder<TDefaultCommand>(args);
         }
 
-        public static SpectreConsoleHostBuilder CreateBuilder(params string[] args) => new SpectreConsoleHostBuilder(args);
+        public static SpectreConsoleHostBuilder CreateBuilder(params string[] args) => new(args);
     }
 }

--- a/SpectreConsoleHost/Builder/SpectreConsoleHostBuilder.cs
+++ b/SpectreConsoleHost/Builder/SpectreConsoleHostBuilder.cs
@@ -7,17 +7,13 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Spectre.Console.Builder.Internal;
 using Spectre.Console.Cli;
-using Spectre.Console.Extensions.Hosting;
 using Spectre.Console.Extensions.Hosting.Internal;
 
 namespace Spectre.Console.Builder
 {
-    internal class SpectreConsoleHostBuilder<TDefaultCommand> : SpectreConsoleHostBuilder where TDefaultCommand : class, ICommand
-    {
-        public SpectreConsoleHostBuilder(params string[] args) : base(args, tr => new CommandApp<TDefaultCommand>(tr))
-        {
-        }
-    }
+    internal class SpectreConsoleHostBuilder<TDefaultCommand>(params string[] args)
+        : SpectreConsoleHostBuilder(args, tr => new CommandApp<TDefaultCommand>(tr))
+        where TDefaultCommand : class, ICommand;
 
     public class SpectreConsoleHostBuilder : IHostApplicationBuilder
     {

--- a/SpectreConsoleHost/Extensions/Hosting/Internal/SpectreConsoleHostTypeRegistrar.cs
+++ b/SpectreConsoleHost/Extensions/Hosting/Internal/SpectreConsoleHostTypeRegistrar.cs
@@ -6,15 +6,9 @@ using Spectre.Console.Cli;
 
 namespace Spectre.Console.Extensions.Hosting.Internal
 {
-    internal class SpectreConsoleHostTypeRegistrar : ITypeRegistrar
+    internal class SpectreConsoleHostTypeRegistrar(Func<IServiceProvider> getServiceProvider) : ITypeRegistrar
     {
         private readonly Dictionary<Type, List<Func<IServiceProvider, object>>> _factories = new Dictionary<Type, List<Func<IServiceProvider, object>>>();
-        private readonly Func<IServiceProvider> _getServiceProvider;
-
-        public SpectreConsoleHostTypeRegistrar(Func<IServiceProvider> getServiceProvider)
-        {
-            _getServiceProvider = getServiceProvider;
-        }
 
         public void Register(Type service, Type implementation)
         {
@@ -36,7 +30,7 @@ namespace Spectre.Console.Extensions.Hosting.Internal
         {
             return new SpectreConsoleHostTypeResolver(
                 _factories.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.AsReadOnly()).AsReadOnly(),
-                _getServiceProvider());
+                getServiceProvider());
         }
 
         private List<Func<IServiceProvider, object>> GetFactoryList(Type service)

--- a/SpectreConsoleHost/Extensions/Hosting/Internal/SpectreConsoleHostTypeResolver.cs
+++ b/SpectreConsoleHost/Extensions/Hosting/Internal/SpectreConsoleHostTypeResolver.cs
@@ -5,24 +5,18 @@ using Spectre.Console.Cli;
 
 namespace Spectre.Console.Extensions.Hosting.Internal
 {
-    internal class SpectreConsoleHostTypeResolver : ITypeResolver
+    internal class SpectreConsoleHostTypeResolver(
+        ReadOnlyDictionary<Type, ReadOnlyCollection<Func<IServiceProvider, object>>> serviceFactories,
+        IServiceProvider serviceProvider)
+        : ITypeResolver
     {
-        private readonly ReadOnlyDictionary<Type, ReadOnlyCollection<Func<IServiceProvider, object>>> _serviceFactories;
-        private readonly IServiceProvider _serviceProvider;
-
-        public SpectreConsoleHostTypeResolver(ReadOnlyDictionary<Type, ReadOnlyCollection<Func<IServiceProvider, object>>> serviceFactories, IServiceProvider serviceProvider)
-        {
-            _serviceFactories = serviceFactories;
-            _serviceProvider = serviceProvider;
-        }
-
         public object Resolve(Type type)
         {
             if (type is null)
                 return null;
 
-            Func<IServiceProvider, object> typeFactory = _serviceFactories.GetValueOrDefault(type)?.LastOrDefault();
-            return typeFactory is null ? _serviceProvider.GetService(type) : typeFactory(_serviceProvider);
+            Func<IServiceProvider, object> typeFactory = serviceFactories.GetValueOrDefault(type)?.LastOrDefault();
+            return typeFactory is null ? serviceProvider.GetService(type) : typeFactory(serviceProvider);
         }
     }
 }

--- a/SpectreConsoleHost/Extensions/Hosting/Internal/SpectreConsoleHostedService.cs
+++ b/SpectreConsoleHost/Extensions/Hosting/Internal/SpectreConsoleHostedService.cs
@@ -8,27 +8,19 @@ using Microsoft.Extensions.Logging;
 
 namespace Spectre.Console.Extensions.Hosting.Internal
 {
-    internal class SpectreConsoleHostedService : IHostedService
+    internal class SpectreConsoleHostedService(
+        IHostApplicationLifetime applicationLifetime,
+        IEnumerable<ExecuteCommandAppDelegate> commandAppExecuteDelegates,
+        ILogger<SpectreConsoleHostedService> logger)
+        : IHostedService
     {
         private int _exitCode;
-        private readonly IHostApplicationLifetime _applicationLifetime;
-        private readonly IEnumerable<ExecuteCommandAppDelegate> _commandAppExecuteDelegates;
-        private readonly ILogger<SpectreConsoleHostedService> _logger;
-
-        public SpectreConsoleHostedService(IHostApplicationLifetime applicationLifetime,
-            IEnumerable<ExecuteCommandAppDelegate> commandAppExecuteDelegates,
-            ILogger<SpectreConsoleHostedService> logger)
-        {
-            _applicationLifetime = applicationLifetime;
-            _commandAppExecuteDelegates = commandAppExecuteDelegates;
-            _logger = logger;
-        }
 
         public Task StartAsync(CancellationToken cancellationToken)
         {
             _ = RunCommandAppsAsync();
 
-            _logger.LogDebug("Spectre Console Hosted service is started.");
+            logger.LogDebug("Spectre Console Hosted service is started.");
 
             return Task.CompletedTask;
         }
@@ -37,12 +29,12 @@ namespace Spectre.Console.Extensions.Hosting.Internal
         {
             try
             {
-                IEnumerable<Task> tasks = _commandAppExecuteDelegates.Select(RunCommandAppAsync);
+                IEnumerable<Task> tasks = commandAppExecuteDelegates.Select(RunCommandAppAsync);
                 await Task.WhenAll(tasks).ConfigureAwait(false);
             }
             finally
             {
-                _applicationLifetime.StopApplication();
+                applicationLifetime.StopApplication();
             }
         }
 
@@ -50,19 +42,19 @@ namespace Spectre.Console.Extensions.Hosting.Internal
         {
             try
             {
-                _logger.LogDebug("Running command app");
+                logger.LogDebug("Running command app");
                 _exitCode = await executeCommandAppDelegate().ConfigureAwait(false);
             }
             catch (Exception ex) when (!(ex is OperationCanceledException))
             {
-                _logger.LogError(ex, "Unhandled exception");
+                logger.LogError(ex, "Unhandled exception");
                 _exitCode = -1;
             }
         }
 
         public Task StopAsync(CancellationToken cancellationToken)
         {
-            _logger.LogDebug("Setting exit code: {exitCode}", _exitCode);
+            logger.LogDebug("Setting exit code: {exitCode}", _exitCode);
 
             Environment.ExitCode = _exitCode;
 

--- a/SpectreConsoleHost/SpectreConsoleHost.csproj
+++ b/SpectreConsoleHost/SpectreConsoleHost.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net7.0;net8.0;netstandard2.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
         <RootNamespace>Spectre.Console</RootNamespace>
-        <LangVersion>7.3</LangVersion>
+        <LangVersion>default</LangVersion>
         <Title>SpectreConsoleHost</Title>
         <Authors>snargledorf</Authors>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
@@ -11,16 +11,18 @@
         <RepositoryUrl>https://github.com/snargledorf/SpectreConsoleHost.git</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <Description>A generic host builder for Spectre.Console</Description>
-        <Version>1.1.0</Version>
+        <Version>2.0.0</Version>
+        <Nullable>disable</Nullable>
+        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
-      <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
-      <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
-      <PackageReference Include="Spectre.Console" Version="0.49.1" />
-      <PackageReference Include="Spectre.Console.Cli" Version="0.49.1" />
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.7" />
+      <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.7" />
+      <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.7" />
+      <PackageReference Include="Spectre.Console" Version="0.55.2" />
+      <PackageReference Include="Spectre.Console.Cli" Version="0.55.0" />
     </ItemGroup>
     
     <ItemGroup>


### PR DESCRIPTION
This PR updates several host builder dependencies to use the latest stable versions (e.g., `Microsoft.Extensions.*` v10) and narrows target frameworks where appropriate.

It also significantly refactors internal classes within `SpectreConsoleHost` to leverage modern C# primary constructors, improving readability and simplifying class structure across the component.