### PR TITLE
Support cancellation tokens for command app execution

### DIFF
--- a/SpectreConsoleHost/Extensions/Hosting/Internal/ExecuteCommandAppDelegate.cs
+++ b/SpectreConsoleHost/Extensions/Hosting/Internal/ExecuteCommandAppDelegate.cs
@@ -1,6 +1,7 @@
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Spectre.Console.Extensions.Hosting.Internal
 {
-    internal delegate Task<int> ExecuteCommandAppDelegate();
+    internal delegate Task<int> ExecuteCommandAppDelegate(CancellationToken cancellationToken);
 }

--- a/SpectreConsoleHost/Extensions/Hosting/Internal/ServiceCollectionExtensions.cs
+++ b/SpectreConsoleHost/Extensions/Hosting/Internal/ServiceCollectionExtensions.cs
@@ -36,12 +36,12 @@ namespace Spectre.Console.Extensions.Hosting.Internal
             {
                 provideServiceProvider?.Invoke(sp);
                 
-                return () =>
+                return cancellationToken =>
                 {
                     if (configure != null)
                         commandApp.Configure(configure);
                     
-                    return commandApp.RunAsync(args);
+                    return commandApp.RunAsync(args, cancellationToken);
                 };
             });
             

--- a/SpectreConsoleHost/Extensions/Hosting/Internal/SpectreConsoleHostedService.cs
+++ b/SpectreConsoleHost/Extensions/Hosting/Internal/SpectreConsoleHostedService.cs
@@ -18,18 +18,19 @@ namespace Spectre.Console.Extensions.Hosting.Internal
 
         public Task StartAsync(CancellationToken cancellationToken)
         {
-            _ = RunCommandAppsAsync();
+            _ = RunCommandAppsAsync(cancellationToken);
 
             logger.LogDebug("Spectre Console Hosted service is started.");
 
             return Task.CompletedTask;
         }
 
-        private async Task RunCommandAppsAsync()
+        private async Task RunCommandAppsAsync(CancellationToken cancellationToken)
         {
             try
             {
-                IEnumerable<Task> tasks = commandAppExecuteDelegates.Select(RunCommandAppAsync);
+                IEnumerable<Task> tasks =
+                    commandAppExecuteDelegates.Select((del) => RunCommandAppAsync(del, cancellationToken));
                 await Task.WhenAll(tasks).ConfigureAwait(false);
             }
             finally
@@ -38,12 +39,12 @@ namespace Spectre.Console.Extensions.Hosting.Internal
             }
         }
 
-        private async Task RunCommandAppAsync(ExecuteCommandAppDelegate executeCommandAppDelegate)
+        private async Task RunCommandAppAsync(ExecuteCommandAppDelegate executeCommandAppDelegate, CancellationToken cancellationToken)
         {
             try
             {
                 logger.LogDebug("Running command app");
-                _exitCode = await executeCommandAppDelegate().ConfigureAwait(false);
+                _exitCode = await executeCommandAppDelegate(cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex) when (!(ex is OperationCanceledException))
             {


### PR DESCRIPTION
This feature introduces support for `CancellationToken` across the hosted service lifecycle within the command application. This ensures that graceful shutdown and proper handling of cancellation requests are managed effectively during runtime by propagating the token through delegate definitions and service collection extensions.